### PR TITLE
Add 'open' attribute to dialog element

### DIFF
--- a/jquery-accessible-dialog-tooltip-aria.js
+++ b/jquery-accessible-dialog-tooltip-aria.js
@@ -57,7 +57,7 @@ $(document).ready(function(){
       $('.js-tooltip').removeClass('is-active');
          
       // insert code at the end
-      $tooltip_code = '<dialog id="js-tooltip" class="js-dialogtooltip ' + $tooltip_prefix_class + 'tooltip" data-launched-by="click" role="dialog" aria-labelledby="tooltip-title"><div role="document">';
+      $tooltip_code = '<dialog id="js-tooltip" class="js-dialogtooltip ' + $tooltip_prefix_class + 'tooltip" data-launched-by="click" role="dialog" aria-labelledby="tooltip-title" open><div role="document">';
       $tooltip_code += '<button id="js-tooltip-close" class="' + $tooltip_prefix_class + 'tooltip__close" data-focus-back="' + $tooltip_starter_id + '" title="' + $tooltip_close_title + '">' + $tooltip_close_text + '</button>';
       if ($tooltip_title !== ''){
          $tooltip_code += '<h1 id="tooltip-title" class="tooltip-title ' + $tooltip_prefix_class + 'tooltip__title">' + $tooltip_title + '</h1>';


### PR DESCRIPTION
https://developer.mozilla.org/en/docs/Web/HTML/Element/dialog

The dialog element should have the attribute 'open'. Chrome supports this element but puts display: none on the dialog if it's not 'open'.